### PR TITLE
134-removed Processed Within column

### DIFF
--- a/app/views/leads/index.html.erb
+++ b/app/views/leads/index.html.erb
@@ -24,7 +24,6 @@
                 <th>Phone</th>
                 <th>Hot?</th>
                 <th>Appointment Date</th>
-                <th>Processed Within</th>
               </tr>
             </thead>
             <tbody>
@@ -36,7 +35,6 @@
                 <td>{{ lead.phone }}</td>
                 <td>{{ lead.hot }}</td>
                 <td>{{ moment(lead.appointment_date).format('dddd MMM Do YYYY, h:mm a') }}</td>
-                <td>{{ lead.processed_within_minutes }}</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
![image](https://trello-attachments.s3.amazonaws.com/5a1c4d643bcada3ace7618b8/5a1c4d643bcada3ace7618c3/ab08aa079a86b391b287115509d87645/Screen_Shot_2017-11-30_at_6.54.01_PM.png)

[link to trello](https://trello.com/c/nNM8Or93/5-134-remove-the-processed-within-column-from-the-leads-index-page)

Hi guys! We removed the `Processed Within` column!